### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -1,6 +1,9 @@
 # This is a basic workflow to help you get started with Actions
 
 name: Package Release
+permissions:
+  contents: read
+  packages: write
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/TensionDev/Navigation/security/code-scanning/2](https://github.com/TensionDev/Navigation/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the tasks performed in the workflow, the following permissions are necessary:
- `contents: read` for accessing the repository contents.
- `packages: write` for pushing NuGet packages.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`build`) in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
