### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/TensionDev/Navigation/security/code-scanning/1](https://github.com/TensionDev/Navigation/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for interacting with pull requests (if applicable).
- `id-token: write` for fetching an OpenID Connect token (if required by SonarCloud).

We will start with `contents: read` as the minimal permission and add others only if explicitly required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
